### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/semantic/lib/nn/parallel/data_parallel.py
+++ b/semantic/lib/nn/parallel/data_parallel.py
@@ -14,7 +14,7 @@ def async_copy_to(obj, dev, main_stream=None):
     if torch.is_tensor(obj):
         obj = Variable(obj)
     if isinstance(obj, Variable):
-        v = obj.cuda(dev, async=True)
+        v = obj.cuda(dev, non_blocking=True)
         if main_stream is not None:
             v.data.record_stream(main_stream)
         return v


### PR DESCRIPTION
In v0.4.0 PyTorch swithced from __async__ to __non_blocking__ to avoid this Python syntax error.  https://github.com/pytorch/pytorch/releases/tag/v0.4.0

[flake8](http://flake8.pycqa.org) testing of https://github.com/ysymyth/3D-SDN on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./semantic/lib/nn/parallel/data_parallel.py:17:31: E999 SyntaxError: invalid syntax
        v = obj.cuda(dev, async=True)
                              ^
./textural/models/networks.py:96:16: F821 undefined name 'E_NLayers'
        netE = E_NLayers(input_nc, output_nc, ndf, n_layers=4, norm_layer=norm_layer,
               ^
./textural/models/networks.py:99:16: F821 undefined name 'E_NLayers'
        netE = E_NLayers(input_nc, output_nc, ndf, n_layers=5, norm_layer=norm_layer,
               ^
1     E999 SyntaxError: invalid syntax
2     F821 undefined name 'E_NLayers'
3
```